### PR TITLE
Replace wget with cURL

### DIFF
--- a/internal/scripts/setup-vagrant.sh
+++ b/internal/scripts/setup-vagrant.sh
@@ -4,7 +4,7 @@ set -o pipefail
 set -x
 
 if [[ ! -e /usr/bin/docker ]]; then
-	wget -qO- https://get.docker.com/ | bash
+	curl -sSL https://get.docker.com/ | bash
 fi
 usermod -aG docker vagrant
 if ! grep -q 'cd /vagrant' ~vagrant/.profile; then


### PR DESCRIPTION
wget cannot connect to the get.docker.com HTTPS URL - it fails with a HTTPS error.

curl works fine.

Error I received:
```shell
--2015-09-15 18:09:58--  https://get.docker.com/
Resolving get.docker.com (get.docker.com)... 54.230.59.225, 54.192.59.20, 54.230.58.52, ...
Connecting to get.docker.com (get.docker.com)|54.230.59.225|:443... connected.
OpenSSL: error:14077410:SSL routines:SSL23_GET_SERVER_HELLO:sslv3 alert handshake failure
Unable to establish SSL connection.
```