### PR TITLE
Support cross-compilation through emulation

### DIFF
--- a/build
+++ b/build
@@ -189,6 +189,25 @@ else
 		/system/internal/scripts/inituidgid.sh \
 		/system/internal/scripts/initccache.sh
 
+	needs_cross_compile=0
+  for arch in $ARCHITECTURES; do
+		case "$arch" in
+			# Architectures that don't need cross-compiling go here
+			amd64|i386)
+					;;
+			*)
+					needs_cross_compile=1
+					;;
+			esac
+	done
+
+	if [ "$needs_cross_compile" != "0" ] ; then
+		# Downloads and registers qemu emulators for non x86/amd64 architectures
+		# Safe to rerun multiple times
+		echo "+ Registering cross-architecture emulators"
+		docker run --rm --privileged multiarch/qemu-user-static --reset -p yes > /dev/null
+  fi
+
 	echo "-------- Entering Docker container --------"
 	exec docker run \
 		--rm $TTY_ARGS \

--- a/docker-images/buildbox/pbuilderrc
+++ b/docker-images/buildbox/pbuilderrc
@@ -2,3 +2,5 @@
 CCACHEDIR=/var/cache/pbuilder/ccache/$DIST-$ARCH
 mkdir -p $CCACHEDIR
 chown app:app $CCACHEDIR
+# More modern and reliable when cross-compiling
+PBUILDERSATISFYDEPENDSCMD=/usr/lib/pbuilder/pbuilder-satisfydepends-apt


### PR DESCRIPTION
This has been used to successfully produce arm64 packages of passenger OSS and
passenger enterprise for ubuntu bionic and focal.  No other packages have
been tested nor have test scripts been updated to support multiple
architectures.

This took about an hour to build on a 2017 macbook pro inside vagrant (2.9 ghz,
16gb RAM) so it isn't exactly speedy.  But the resulting debs have been validated 
on an aws gravitron2 instance.