### PR TITLE
Use RubyGems 3.1.5 for buildbox Image

### DIFF
--- a/docker-images/buildbox/install.sh
+++ b/docker-images/buildbox/install.sh
@@ -55,7 +55,7 @@ run apt-get install -y -q ubuntu-dev-tools debhelper source-highlight \
 	ruby ruby-dev libsqlite3-dev runit git gawk dh-make dirmngr debian-keyring \
 	zlib1g-dev libxml2-dev libxslt1-dev gdebi-core gnupg dh-systemd
 run gem install rake bundler --no-document
-run gem update --system --no-document
+run gem update --system 3.1.5 --no-document
 run env BUNDLE_GEMFILE=/paa_build/Gemfile bundle install
 
 header "Importing public keys"


### PR DESCRIPTION
This fixes the following exception during build:

    uninitialized constant Gem::BasicSpecification (NameError)

It is caused by an incompatibility between Ruby 2.5 and Rubygems 3.2.3.

The currently published image `phusion/passenger_apt_automation_buildbox:1.1.8` uses 3.1.4, which was current at the time of build.