### PR TITLE
Fix building on native arm64 system

### DIFF
--- a/internal/build/setup-environment.sh
+++ b/internal/build/setup-environment.sh
@@ -13,8 +13,9 @@ source "$ROOTDIR/internal/lib/library.sh"
 require_args_exact 2 "$@"
 DISTRO="$1"
 ARCH="$2"
+HOSTARCH=`dpkg --print-architecture`
 
-if [[ $ARCH == amd64 ]]; then
+if [[ $ARCH == $HOSTARCH ]]; then
 	BASE_TGZ="$DISTRO-base.tgz"
 else
 	BASE_TGZ="$DISTRO-$ARCH-base.tgz"


### PR DESCRIPTION
This fixes a problem where the build script expects to find `base-arm64-focal.tgz` instead of the actual `base-focal.tgz` by inspecting `dpkg --print-architecture` instead of hardcoding `amd64` as the native host arch.