### PR TITLE
Add Arm support

### DIFF
--- a/docker-images/buildbox/Dockerfile
+++ b/docker-images/buildbox/Dockerfile
@@ -1,3 +1,3 @@
-FROM phusion/baseimage:impish
+FROM phusion/baseimage:jammy-1.0.1
 ADD . /paa_build
 RUN bash /paa_build/install.sh

--- a/internal/test/test.sh
+++ b/internal/test/test.sh
@@ -2,6 +2,7 @@
 set -e
 ROOTDIR=$(dirname "$0")
 ROOTDIR=$(cd "$ROOTDIR/../.." && pwd)
+ARCH=$(dpkg --print-architecture)
 # shellcheck source=../lib/library.sh
 source "$ROOTDIR/internal/lib/library.sh"
 
@@ -29,26 +30,26 @@ echo
 header "Installing packages..."
 run apt-get update -q
 if ls /output/*enterprise* >/dev/null 2>/dev/null; then
-	run gdebi -n -q /output/passenger-enterprise_*_amd64.deb
-	run gdebi -n -q /output/passenger-enterprise-dbg_*_amd64.deb
-	run gdebi -n -q /output/passenger-enterprise-dev_*_amd64.deb
+	run gdebi -n -q /output/passenger-enterprise_*_$ARCH.deb
+	run gdebi -n -q /output/passenger-enterprise-dbg_*_$ARCH.deb
+	run gdebi -n -q /output/passenger-enterprise-dev_*_$ARCH.deb
 	run gdebi -n -q /output/passenger-enterprise-doc_*_all.deb
-	run gdebi -n -q /output/libapache2-mod-passenger-enterprise_*_amd64.deb
+	run gdebi -n -q /output/libapache2-mod-passenger-enterprise_*_$ARCH.deb
 else
-	run gdebi -n -q /output/passenger_*_amd64.deb
-	run gdebi -n -q /output/passenger-dbg_*_amd64.deb
-	run gdebi -n -q /output/passenger-dev_*_amd64.deb
+	run gdebi -n -q /output/passenger_*_$ARCH.deb
+	run gdebi -n -q /output/passenger-dbg_*_$ARCH.deb
+	run gdebi -n -q /output/passenger-dev_*_$ARCH.deb
 	run gdebi -n -q /output/passenger-doc_*_all.deb
-	run gdebi -n -q /output/libapache2-mod-passenger_*_amd64.deb
+	run gdebi -n -q /output/libapache2-mod-passenger_*_$ARCH.deb
 fi
 if ! ls /output/libnginx-mod-http-passenger* >/dev/null 2>/dev/null; then
 	run gdebi -n -q /output/nginx-common_*_all.deb
-	run gdebi -n -q /output/nginx-extras_*_amd64.deb
+	run gdebi -n -q /output/nginx-extras_*_$ARCH.deb
 elif ls /output/*enterprise* >/dev/null 2>/dev/null; then
-	run gdebi -n -q /output/libnginx-mod-http-passenger-enterprise_*_amd64.deb
+	run gdebi -n -q /output/libnginx-mod-http-passenger-enterprise_*_$ARCH.deb
 	run apt-get install -y -q "${NGINX_DEV_PACKAGES[@]}"
 else
-	run gdebi -n -q /output/libnginx-mod-http-passenger_*_amd64.deb
+	run gdebi -n -q /output/libnginx-mod-http-passenger_*_$ARCH.deb
 	run apt-get install -y -q "${NGINX_DEV_PACKAGES[@]}"
 fi
 run apt-get install -y -q "${APACHE2_DEV_PACKAGES[@]}"


### PR DESCRIPTION
Using following instructions: https://github.com/phusion/passenger-docker/issues/286#issuecomment-1252758811

I have built packages for ARM using:  AWS Linux Instance, ARM, Ubuntu 22LTS

In this PR I did a little tweak to make it works

1. All packages were created using `build` command
2. Packages were tested using `test` command -> All tests are green

All comments and reviews are welcome!

Little bit later I will add link with to the tag.gz with all packages that I made